### PR TITLE
feat: add background logo and advanced settings

### DIFF
--- a/public/z-logo.svg
+++ b/public/z-logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#000"/>
+  <path fill="#fff" d="M10 10h80v20H50l40 40v20H10V70h50L10 30z"/>
+</svg>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,6 +17,8 @@ const HomePage = () => {
     wireframe: false
   })
   const [rotationSpeed, setRotationSpeed] = useState(1)
+  const [autoRotate, setAutoRotate] = useState(true)
+  const [showLogo, setShowLogo] = useState(true)
   const [codes, setCodes] = useState<string[]>(['', '', '', '', '', ''])
   const [error, setError] = useState<string | null>(null)
   
@@ -157,13 +159,10 @@ const HomePage = () => {
               shape={shape}
               effects={effects}
               materialType={materialType}
+              rotationSpeed={rotationSpeed}
+              autoRotate={autoRotate}
+              showLogo={showLogo}
             />
-            
-            {/* Overlay Instructions */}
-            <div className="absolute top-4 left-4 bg-black/50 backdrop-blur-sm rounded-lg p-3 text-sm text-white/80">
-              <p>🖱️ Drag to rotate • Scroll to zoom</p>
-              <p>⌨️ Ctrl+Enter to generate</p>
-            </div>
           </div>
 
           {/* Controls Panel */}
@@ -183,6 +182,10 @@ const HomePage = () => {
               setRotationSpeed={setRotationSpeed}
               materialType={materialType}
               setMaterialType={setMaterialType}
+              autoRotate={autoRotate}
+              setAutoRotate={setAutoRotate}
+              showLogo={showLogo}
+              setShowLogo={setShowLogo}
             />
           </div>
         </div>

--- a/src/components/3d-code-visualization.tsx
+++ b/src/components/3d-code-visualization.tsx
@@ -2,7 +2,7 @@
 
 import React, { useRef, useState, useEffect } from 'react'
 import { Canvas, useFrame, useThree } from '@react-three/fiber'
-import { OrbitControls, Text, Box, Sphere, Environment, Float, useTexture } from '@react-three/drei'
+import { OrbitControls, Text, Box, Sphere, Environment, Float } from '@react-three/drei'
 import * as THREE from 'three'
 
 interface CodeFaceProps {
@@ -250,13 +250,13 @@ const CodeFace: React.FC<CodeFaceProps> = ({ position, rotation, code, label, th
   )
 }
 
-const CodeSphere: React.FC<{ code: string; theme: Theme; materialType: string }> = ({ code, theme, materialType }) => {
+const CodeSphere: React.FC<{ code: string; theme: Theme; materialType: string; rotationSpeed: number }> = ({ code, theme, materialType, rotationSpeed }) => {
   const meshRef = useRef<THREE.Mesh>(null)
-  
-  useFrame((state) => {
+
+  useFrame(() => {
     if (meshRef.current) {
-      meshRef.current.rotation.y += 0.005
-      meshRef.current.rotation.x += 0.002
+      meshRef.current.rotation.y += 0.005 * rotationSpeed
+      meshRef.current.rotation.x += 0.002 * rotationSpeed
     }
   })
 
@@ -306,13 +306,13 @@ const CodeSphere: React.FC<{ code: string; theme: Theme; materialType: string }>
   )
 }
 
-const CodeCube: React.FC<{ faceCodes: string[]; theme: Theme; materialType: string }> = ({ faceCodes, theme, materialType }) => {
+const CodeCube: React.FC<{ faceCodes: string[]; theme: Theme; materialType: string; rotationSpeed: number }> = ({ faceCodes, theme, materialType, rotationSpeed }) => {
   const groupRef = useRef<THREE.Group>(null)
-  
-  useFrame((state) => {
+
+  useFrame(() => {
     if (groupRef.current) {
-      groupRef.current.rotation.x += 0.003
-      groupRef.current.rotation.y += 0.005
+      groupRef.current.rotation.x += 0.003 * rotationSpeed
+      groupRef.current.rotation.y += 0.005 * rotationSpeed
     }
   })
 
@@ -373,14 +373,18 @@ interface ThreeDVisualizationProps {
     wireframe: boolean
   }
   materialType: 'glass' | 'reflective' | 'matte' | 'glowing' | 'crystal' | 'metallic'
+  rotationSpeed: number
+  autoRotate: boolean
 }
 
-const ThreeDVisualization: React.FC<ThreeDVisualizationProps> = ({ 
-  codes, 
-  theme, 
-  shape, 
+const ThreeDVisualization: React.FC<ThreeDVisualizationProps> = ({
+  codes,
+  theme,
+  shape,
   effects,
-  materialType
+  materialType,
+  rotationSpeed,
+  autoRotate
 }) => {
   const { scene } = useThree()
   
@@ -407,21 +411,21 @@ const ThreeDVisualization: React.FC<ThreeDVisualizationProps> = ({
       <Environment preset="city" />
       
       {shape === 'cube' ? (
-        <CodeCube faceCodes={codes} theme={theme} materialType={materialType} />
+        <CodeCube faceCodes={codes} theme={theme} materialType={materialType} rotationSpeed={rotationSpeed} />
       ) : (
-        <CodeSphere code={codes.join('\n')} theme={theme} materialType={materialType} />
+        <CodeSphere code={codes.join('\n')} theme={theme} materialType={materialType} rotationSpeed={rotationSpeed} />
       )}
       
       {effects.particles && (
         <Particles color={theme.primary} />
       )}
       
-      <OrbitControls 
-        enablePan={true} 
-        enableZoom={true} 
+      <OrbitControls
+        enablePan={true}
+        enableZoom={true}
         enableRotate={true}
-        autoRotate={true}
-        autoRotateSpeed={0.5}
+        autoRotate={autoRotate}
+        autoRotateSpeed={rotationSpeed * 0.5}
         minDistance={3}
         maxDistance={15}
       />
@@ -493,6 +497,9 @@ interface CodeVisualizationProps {
     wireframe: boolean
   }
   materialType: 'glass' | 'reflective' | 'matte' | 'glowing' | 'crystal' | 'metallic'
+  rotationSpeed: number
+  autoRotate: boolean
+  showLogo: boolean
 }
 
 export const CodeVisualization: React.FC<CodeVisualizationProps> = ({
@@ -500,27 +507,41 @@ export const CodeVisualization: React.FC<CodeVisualizationProps> = ({
   currentTheme,
   shape,
   effects,
-  materialType
+  materialType,
+  rotationSpeed,
+  autoRotate,
+  showLogo
 }) => {
   const theme = themes[currentTheme]
 
   return (
-    <div className="w-full h-full">
+    <div
+      className="w-full h-full"
+      style={{
+        backgroundColor: theme.background,
+        backgroundImage: showLogo ? "url('/z-logo.svg')" : undefined,
+        backgroundRepeat: 'no-repeat',
+        backgroundPosition: 'center',
+        backgroundSize: '20%',
+      }}
+    >
       <Canvas
         camera={{ position: [0, 0, 8], fov: 60 }}
-        style={{ background: theme.background }}
-        gl={{ 
+        style={{ background: 'transparent' }}
+        gl={{
           antialias: true,
           alpha: true,
-          powerPreference: "high-performance"
+          powerPreference: "high-performance",
         }}
       >
-        <ThreeDVisualization 
-          codes={codes} 
-          theme={theme} 
-          shape={shape} 
+        <ThreeDVisualization
+          codes={codes}
+          theme={theme}
+          shape={shape}
           effects={effects}
           materialType={materialType}
+          rotationSpeed={rotationSpeed}
+          autoRotate={autoRotate}
         />
       </Canvas>
     </div>

--- a/src/components/controls-panel.tsx
+++ b/src/components/controls-panel.tsx
@@ -7,6 +7,7 @@ import { Switch } from '@/components/ui/switch'
 import { Label } from '@/components/ui/label'
 import { Badge } from '@/components/ui/badge'
 import { themes, Theme } from '@/components/3d-code-visualization'
+import { Settings2 } from 'lucide-react'
 
 interface ControlsPanelProps {
   prompt: string
@@ -27,6 +28,10 @@ interface ControlsPanelProps {
   setRotationSpeed: (speed: number) => void
   materialType: 'glass' | 'reflective' | 'matte' | 'glowing' | 'crystal' | 'metallic'
   setMaterialType: (type: 'glass' | 'reflective' | 'matte' | 'glowing' | 'crystal' | 'metallic') => void
+  autoRotate: boolean
+  setAutoRotate: (value: boolean) => void
+  showLogo: boolean
+  setShowLogo: (value: boolean) => void
 }
 
 export const ControlsPanel: React.FC<ControlsPanelProps> = ({
@@ -43,7 +48,11 @@ export const ControlsPanel: React.FC<ControlsPanelProps> = ({
   rotationSpeed,
   setRotationSpeed,
   materialType,
-  setMaterialType
+  setMaterialType,
+  autoRotate,
+  setAutoRotate,
+  showLogo,
+  setShowLogo
 }) => {
   const handleEffectToggle = (effect: keyof typeof effects) => {
     setEffects({
@@ -51,6 +60,8 @@ export const ControlsPanel: React.FC<ControlsPanelProps> = ({
       [effect]: !effects[effect]
     })
   }
+
+  const [showAdvanced, setShowAdvanced] = React.useState(false)
 
   const materialOptions = [
     { value: 'glass', label: 'Glass', color: 'rgba(100, 200, 255, 0.3)' },
@@ -62,7 +73,16 @@ export const ControlsPanel: React.FC<ControlsPanelProps> = ({
   ]
 
   return (
-    <div className="w-full max-w-md space-y-4 p-4 bg-black/20 backdrop-blur-sm rounded-lg border border-white/10">
+    <div className="relative w-full max-w-md space-y-4 p-4 bg-black/20 backdrop-blur-sm rounded-lg border border-white/10">
+      <Button
+        variant="ghost"
+        size="icon"
+        className="absolute top-2 right-2"
+        onClick={() => setShowAdvanced(!showAdvanced)}
+        aria-label="Toggle advanced settings"
+      >
+        <Settings2 className="h-4 w-4" />
+      </Button>
       {/* Prompt Input */}
       <Card className="bg-black/30 border-white/10">
         <CardHeader>
@@ -207,33 +227,52 @@ export const ControlsPanel: React.FC<ControlsPanelProps> = ({
         </CardContent>
       </Card>
 
-      {/* Rotation Speed */}
-      <Card className="bg-black/30 border-white/10">
-        <CardHeader>
-          <CardTitle className="text-white">Rotation Speed</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="flex items-center gap-2">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => setRotationSpeed(Math.max(0, rotationSpeed - 0.5))}
-            >
-              -
-            </Button>
-            <Badge variant="secondary" className="flex-1 text-center">
-              {rotationSpeed}x
-            </Badge>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => setRotationSpeed(Math.min(3, rotationSpeed + 0.5))}
-            >
-              +
-            </Button>
-          </div>
-        </CardContent>
-      </Card>
+      {showAdvanced && (
+        <>
+          <Card className="bg-black/30 border-white/10">
+            <CardHeader>
+              <CardTitle className="text-white">Rotation Speed</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="flex items-center gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setRotationSpeed(Math.max(0, rotationSpeed - 0.5))}
+                >
+                  -
+                </Button>
+                <Badge variant="secondary" className="flex-1 text-center">
+                  {rotationSpeed}x
+                </Badge>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setRotationSpeed(Math.min(3, rotationSpeed + 0.5))}
+                >
+                  +
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card className="bg-black/30 border-white/10">
+            <CardHeader>
+              <CardTitle className="text-white">Advanced Options</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <div className="flex items-center justify-between">
+                <Label htmlFor="autorotate" className="text-white/80">Auto Rotate</Label>
+                <Switch id="autorotate" checked={autoRotate} onCheckedChange={() => setAutoRotate(!autoRotate)} />
+              </div>
+              <div className="flex items-center justify-between">
+                <Label htmlFor="showlogo" className="text-white/80">Show Background Logo</Label>
+                <Switch id="showlogo" checked={showLogo} onCheckedChange={() => setShowLogo(!showLogo)} />
+              </div>
+            </CardContent>
+          </Card>
+        </>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- show background logo behind 3D canvas
- add expandable advanced settings with rotation and logo toggles
- remove overlay instructions for unobstructed 3D view

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68afe6bfed9883319e68832be8f60d25